### PR TITLE
Switch before_filter -> before_action

### DIFF
--- a/README
+++ b/README
@@ -37,7 +37,7 @@ Then add the line below to config/initializers/mime_types.rb
 For Skiping setting the Format to :mobile
 Add this line to your Application Controller
 
-  skip_before_filter :set_mobile_format
+  skip_before_action :set_mobile_format
 
 Example
 =======

--- a/lib/active_device/controller_methods.rb
+++ b/lib/active_device/controller_methods.rb
@@ -3,7 +3,7 @@ module ActiveDevice::ControllerMethods
   include ActiveDevice::Helper
 
   def self.included(base)
-    base.before_filter :set_mobile_format
+    base.before_action :set_mobile_format
     base.helper_method :is_mobile_device?, :is_mobile_browser?, :is_desktop_browser?, :is_bot?
     base.helper_method :is_mobile_view?
     base.helper_method :is_device?, :is_handset?, :is_brand?, :is_model?, :is_os?, :is_engine?, :is_browser?


### PR DESCRIPTION
`before_filter` is deprecated in Rails 5.0 and removed in Rails 5.1.
Since the `before_action` syntax looks to have been [added in Rails 4][1],
it should be safe to make this syntax change now, unless this fork is
used by anything on Rails < 4.

[1]: https://github.com/rails/rails/commit/9d62e04838f01f5589fa50b0baa480d60c815e2c